### PR TITLE
Avoid failing the test for a given threshold but yet generating the difference image

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ I.seeVisualDiff("image.png", {prepareBaseImage: true, tolerance: 1, ignoredBox: 
 After this, that specific mentioned part will be ignored while comparison.
 This works for `seeVisualDiff` and `seeVisualDiffForElement`.
 
+### Bypass Failure
+You can avoid the test fails for a given threshold but yet generates the difference image.
+Just declare an object and pass it in options as `bypassFailure`:
+```
+I.seeVisualDiff("image.png", {prepareBaseImage: true, tolerance: 1, bypassFailure: true});
+```
+After this, the system generates the difference image but does not fail the test.
+This works for `seeVisualDiff` and `seeVisualDiffForElement`.
+
 ### Allure Reporter
 Allure reports may also be generated directly from the tool. To do so, add
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ I.seeVisualDiff("image.png", {prepareBaseImage: true, tolerance: 1, ignoredBox: 
 After this, that specific mentioned part will be ignored while comparison.
 This works for `seeVisualDiff` and `seeVisualDiffForElement`.
 
-### Bypass Failure
+### Skip Failure
 You can avoid the test fails for a given threshold but yet generates the difference image.
-Just declare an object and pass it in options as `bypassFailure`:
+Just declare an object and pass it in options as `skipFailure`:
 ```
-I.seeVisualDiff("image.png", {prepareBaseImage: true, tolerance: 1, bypassFailure: true});
+I.seeVisualDiff("image.png", {prepareBaseImage: true, tolerance: 1, skipFailure: true});
 ```
 After this, the system generates the difference image but does not fail the test.
 This works for `seeVisualDiff` and `seeVisualDiffForElement`.

--- a/index.js
+++ b/index.js
@@ -322,7 +322,7 @@ class ResembleHelper extends Helper {
 
     this.debug("MisMatch Percentage Calculated is " + misMatch);
 
-    if (options.bypassFailure === false) {
+    if (options.skipFailure === false) {
       assert(misMatch <= options.tolerance, "MissMatch Percentage " + misMatch);
     }
   }

--- a/index.js
+++ b/index.js
@@ -321,7 +321,10 @@ class ResembleHelper extends Helper {
     }
 
     this.debug("MisMatch Percentage Calculated is " + misMatch);
-    assert(misMatch <= options.tolerance, "MissMatch Percentage " + misMatch);
+
+    if (options.bypassFailure === false) {
+      assert(misMatch <= options.tolerance, "MissMatch Percentage " + misMatch);
+    }
   }
 
   /**


### PR DESCRIPTION
There are scenarios where we want to see the differences but we do not want the pipeline fails with this threshold, e.g. the test with threshold 1 should not fail the pipeline but we want to see the differences anyway.

This branch adds a new option called "skipFailure". If "true" then the system generates the diff file but does not fail the test.