### PR TITLE
Issue #60 - Prepare all baselines of test by setting parameter in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # codeceptjs-resemblehelper
-Helper for resemble.js, used for image comparison in tests with WebdriverIO.
+Helper for resemble.js, used for image comparison in tests with WebdriverIO or Puppeteer.
 
 codeceptjs-resemblehelper is a [CodeceptJS](https://codecept.io/) helper which can be used to compare screenshots and make the tests fail/pass based on the tolerance allowed.
 
@@ -21,19 +21,25 @@ Example:
      "ResembleHelper" : {
        "require": "codeceptjs-resemblehelper",
        "baseFolder": "./tests/screenshots/base/",
-       "diffFolder": "./tests/screenshots/diff/"
+       "diffFolder": "./tests/screenshots/diff/",
+       "prepareBaseImage": true
      }
    }
 }
 ```
 
-To use the Helper, users must provide the two parameters:
+To use the Helper, users may provide the parameters:
 
-`baseFolder`: This is the folder for base images, which will be used with screenshot for comparison.
+`baseFolder`: Mandatory. This is the folder for base images, which will be used with screenshot for comparison.
 
-`diffFolder`: This will the folder where resemble would try to store the difference image, which can be viewed later.
+`diffFolder`: Mandatory. This will the folder where resemble would try to store the difference image, which can be viewed later.
 
-Usage, these are major functions that help in visual testing
+`prepareBaseImage`: Optional. When `true` then the system replaces all of the baselines related to the test case(s) you ran. This is equivalent of setting the option `prepareBaseImage: true` in all verifications of the test file.
+
+
+### Usage
+
+These are the major functions that help in visual testing:
 
 First one is the `seeVisualDiff` which basically takes two parameters
 1) `baseImage` Name of the base image, this will be the image used for comparison with the screenshot image. It is mandatory to have the same image file names for base and screenshot image.

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class ResembleHelper extends Helper {
     this.baseFolder = this.resolvePath(config.baseFolder);
     this.diffFolder = this.resolvePath(config.diffFolder);
     this.screenshotFolder = global.output_dir + "/";
+    this.prepareBaseImage = config.prepareBaseImage;
   }
 
   resolvePath(folderPath) {
@@ -177,7 +178,7 @@ class ResembleHelper extends Helper {
    * @param region
    * @param bucketName
    * @param baseImage
-   * @param ifBaseImage - tells if the prepareBaseImage is true or false. If false, then it won't upload the baseImage.
+   * @param ifBaseImage - tells if the prepareBaseImage is true or false. If false, then it won't upload the baseImage. However, this parameter is not considered if the config file has a prepareBaseImage set to true.
    * @returns {Promise<void>}
    */
 
@@ -294,6 +295,10 @@ class ResembleHelper extends Helper {
     if (!options) {
       options = {};
       options.tolerance = 0;
+    }
+
+    if (this.prepareBaseImage) {
+      options.prepareBaseImage = true;
     }
 
     const awsC = this.config.aws;


### PR DESCRIPTION
Closes issue #60 

This branch adds an optional parameter in **config** file called _prepareBaseImage_. When _true_ then the system replaces all of the baselines related to the test case(s) you ran. This is equivalent of setting the option _prepareBaseImage: true_ in all verifications of the test file.