### PR TITLE
1.9.2 fix bug with default skip failure option (#73)

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,7 +331,7 @@ class ResembleHelper extends Helper {
 
     this.debug("MisMatch Percentage Calculated is " + misMatch + " for baseline " + baseImage);
 
-    if (options.skipFailure === false) {
+    if (!options.skipFailure) {
       assert(misMatch <= options.tolerance, "Screenshot does not match with the baseline " + baseImage + " when MissMatch Percentage is " + misMatch);
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-resemblehelper",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Resemble Js helper for CodeceptJS, with Support for Webdriver, Puppeteer & Appium",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes: https://github.com/codecept-js/codeceptjs-resemblehelper/issues/71 
thanks to @vazsonyidl and @eunicekokor for reporting